### PR TITLE
Stable Rust compatibility

### DIFF
--- a/enum-iter/src/lib.rs
+++ b/enum-iter/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(proc_macro, proc_macro_lib)]
 extern crate proc_macro;
 extern crate syn;
 #[macro_use]


### PR DESCRIPTION
Procedural macros [have started entering stable Rust](https://doc.rust-lang.org/stable/reference/procedural-macros.html) and this crate no longer requires nightly.